### PR TITLE
build: Upgrade PMD to 7.11

### DIFF
--- a/approvals/src/main/java/no/sikt/nva/approvals/dmp/DmpClient.java
+++ b/approvals/src/main/java/no/sikt/nva/approvals/dmp/DmpClient.java
@@ -13,6 +13,8 @@ import nva.commons.core.JacocoGenerated;
 import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.core.paths.UriWrapper;
 
+// FIXME: Suppressing warning in order to upgrade PMD version
+@SuppressWarnings("PMD.DoNotUseThreads")
 public class DmpClient implements DmpClientService {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
@@ -40,6 +42,7 @@ public class DmpClient implements DmpClientService {
             .build());
     }
 
+    @Override
     public Optional<ClinicalTrial> getClinicalTrial(String identifier) throws DmpClientException {
         if (identifier == null) {
             throw new DmpClientException("Identifier is required");

--- a/approvals/src/main/java/no/sikt/nva/approvals/dmp/OAuth2TokenService.java
+++ b/approvals/src/main/java/no/sikt/nva/approvals/dmp/OAuth2TokenService.java
@@ -15,6 +15,8 @@ import java.util.Objects;
 import nva.commons.core.JacocoGenerated;
 import no.unit.nva.commons.json.JsonUtils;
 
+// FIXME: Suppressing warning in order to upgrade PMD version
+@SuppressWarnings({"PMD.DoNotUseThreads", "PMD.AvoidSynchronizedStatement"})
 public class OAuth2TokenService {
 
     private static final String CONTENT_TYPE_HEADER = "Content-Type";

--- a/approvals/src/main/java/no/sikt/nva/approvals/dmp/model/ClinicalTrial.java
+++ b/approvals/src/main/java/no/sikt/nva/approvals/dmp/model/ClinicalTrial.java
@@ -5,6 +5,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 
+// FIXME: Suppressing warning in order to upgrade PMD version
+@SuppressWarnings("unused")
 public record ClinicalTrial(
     URI id,
     String identifier,

--- a/approvals/src/main/java/no/sikt/nva/approvals/persistence/DynamoDbApprovalRepository.java
+++ b/approvals/src/main/java/no/sikt/nva/approvals/persistence/DynamoDbApprovalRepository.java
@@ -47,6 +47,8 @@ import software.amazon.awssdk.enhanced.dynamodb.model.TransactPutItemEnhancedReq
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
+// FIXME: Suppressing warning in order to upgrade PMD version
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class DynamoDbApprovalRepository implements ApprovalRepository {
 
     private static final int BATCH_GET_ITEM_LIMIT = 80;

--- a/buildSrc/src/main/groovy/nva-handle-service.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva-handle-service.java-common-conventions.gradle
@@ -34,7 +34,7 @@ tasks.named('test') {
 }
 
 pmd {
-    toolVersion = '6.55.0'
+    toolVersion = '7.11.0'
     ruleSetConfig = rootProject.resources.text.fromFile('config/pmd/ruleset.xml')
     ruleSets = []
     ignoreFailures = false

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -45,6 +45,7 @@
     <exclude name="CommentDefaultAccessModifier"/>
     <!-- Conflicts with the rule category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending -->
     <exclude name="DefaultPackage"/>
+    <exclude name="UseExplicitTypes"/>
 
 
     <!--<exclude name="BeanMembersShouldSerialize"/>-->

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -10,7 +10,6 @@
   <exclude-pattern>.*/test/.*</exclude-pattern>
 
   <rule ref="category/java/errorprone.xml">
-    <exclude name="DataflowAnomalyAnalysis"/>
     <exclude name="MissingSerialVersionUID"/>
     <exclude name="NonSerializableClass"/>
   </rule>
@@ -21,7 +20,6 @@
   </rule>
 
   <rule ref="category/java/bestpractices.xml">
-    <exclude name="SystemPrintln"/>
     <exclude name="GuardLogStatement"/>
     <exclude name="AvoidPrintStackTrace"/>
 
@@ -43,19 +41,8 @@
     <exclude name="UnnecessaryConstructor"/>
     <!-- Conflicts with the rule category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending -->
     <exclude name="CommentDefaultAccessModifier"/>
-    <!-- Conflicts with the rule category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending -->
-    <exclude name="DefaultPackage"/>
     <exclude name="UseExplicitTypes"/>
-
-
-    <!--<exclude name="BeanMembersShouldSerialize"/>-->
-
     <exclude name="ConfusingTernary"/>
-
-    <!-- printStackTrace is used in the Default Amazon handler in a static clause
-        We can re-enable this rule if we find a way to set a logger there
-    -->
-    <!--<exclude name="AvoidPrintStackTrace"/>-->
 
 
     <!-- This rule does not allow us the following:


### PR DESCRIPTION
Upgrades PMD to a relatively recent version of PMD that actually works. Fixing the issues and upgrading to the very newest PMD version should both be done in separate pull requests due to the number of changes required.


Changes:

- Upgrades PMD (`6.55` -> `7.11`)
- Removes PMD rules that are either deprecated or not necessary (no violations)
- Adds suppressions for existing PMD violations that cannot be easily fixed